### PR TITLE
Add geoCheck() to filter http requests

### DIFF
--- a/src/actions/MessageActionCreator.js
+++ b/src/actions/MessageActionCreator.js
@@ -18,5 +18,6 @@ export default {
     return MessageApi.requestPostMessage(data)
       .then(res => dispatch(createAction(AT.POST_MESSAGE, res)))
   }
+
 }
 

--- a/src/apis/lib.js
+++ b/src/apis/lib.js
@@ -1,4 +1,4 @@
-const ROOT = 'http://polls.apiblueprint.org/'
+const ROOT = 'http://52.78.232.101/'
 
 function checkStatus(response) {
   return response.text()

--- a/src/containers/Messages$/Messages$.js
+++ b/src/containers/Messages$/Messages$.js
@@ -21,11 +21,10 @@ class Messages$ extends React.Component {
   }
   
   componentWillMount() {
-    // this.props.dispatch(MessageActions.getMessages({
-    //   x: this.props.geolocation.x,
-    //   y: this.props.geolocation.y
-    // }))
-
+    this.props.dispatch(MessageActions.getMessages({
+      x: this.props.geolocation.x,
+      y: this.props.geolocation.y
+    }))
   }
 
   render() {

--- a/src/containers/Welcome$/Welcome$.js
+++ b/src/containers/Welcome$/Welcome$.js
@@ -21,7 +21,8 @@ class Welcome$ extends React.Component {
   componentWillMount() {
     this.props.dispatch(GeolocationActions.getGeolocation())
       .then((res) => {
-        console.log('geo', res)
+        // window.sessionStorage.setItem('vtag-geo-x', res.x)
+        // window.sessionStorage.setItem('vtag-geo-y', res.y)
         this.setState({geoIsConfirmed: true})
       })
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,7 @@ import App$ from './containers/App$'
 import Welcome$ from './containers/Welcome$'
 import Messages$ from './containers/Messages$'
 import MainFrame from './components/MainFrame'
-
+import { RouteUtils } from './utils'
 
 
 /************************************************************
@@ -29,7 +29,7 @@ export default (
       <Route path="/" component={App$}>
         <IndexRedirect to="welcome"/>
         <Route path="welcome" component={Welcome$}/>
-        <Route component={MainFrame}>
+        <Route component={MainFrame} onEnter={RouteUtils.geoCheck}>
           <Route path="messages" component={Messages$}/>
         </Route>
       </Route>

--- a/src/utils/RouteUtils.js
+++ b/src/utils/RouteUtils.js
@@ -1,0 +1,11 @@
+export default {
+  geoCheck: (nextState, replace) => {
+    let x = window.sessionStorage.getItem('vtag-geo-x')
+    let y = window.sessionStorage.getItem('vtag-geo-y')
+
+    if (!x || !y) {
+      console.log('Geolocation check failed. Redirect to welcome page')
+      replace('welcome')
+    }
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,9 @@
 import DomUtils from './DomUtils'
 import ReduxUtils from './ReduxUtils'
+import RouteUtils from './RouteUtils'
 
 module.exports = {
   DomUtils,
-  ReduxUtils
+  ReduxUtils,
+  RouteUtils
 }


### PR DESCRIPTION
When a client access the application with url /xxx, the app redirects
the request to /welcome, entry point.

Note that the way of saving and retrieivng the geolocation with SessionStorage
was contemplated, only to be postponed to implement because there is a lot of
things to be considered."